### PR TITLE
profiles: dev-machine: add configuration limit (no more unlimited)

### DIFF
--- a/profiles/dev-machine.nix
+++ b/profiles/dev-machine.nix
@@ -19,5 +19,10 @@
         };
       };
     };
+
+    # Prevent frequent "/boot volume full" errors. Limit this to a sane small
+    # number.
+    boot.loader.grub.configurationLimit = 7;
+    boot.loader.systemd-boot.configurationLimit = 7;
   };
 }


### PR DESCRIPTION
On my developer machines, I often have up to 30 or 40 generations. This wastes disk space. Limiting this to 7 is more than enough to have something I can boot into if I mess up the latest config.

This prevents any more "no space left on /boot" errors.