### PR TITLE
common(modules): consume every extra package from pkgsUnstable

### DIFF
--- a/common/modules/user-env/env/default.nix
+++ b/common/modules/user-env/env/default.nix
@@ -2,11 +2,14 @@
 # dotfiles) and corresponding home-manager settings for the given user. This is
 # intended as a big "all-in-one" module with no further enable sub-options.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   stateVersion = config.system.stateVersion;
   cfg = config.phip1611.common.user-env;
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  };
 in
 {
   imports = [
@@ -45,8 +48,8 @@ in
         # I never came across a case where these variables are needed, however,
         # better be safe so that I can always use my favorite terminal editor in
         # my CLI utilities.
-        EDITOR = "${pkgs.micro}/bin/micro";
-        VISUAL = "${pkgs.micro}/bin/micro";
+        EDITOR = "${pkgsUnstable.micro}/bin/micro";
+        VISUAL = "${pkgsUnstable.micro}/bin/micro";
 
         # Configuration for LESS pager.
         LESS = "-R --mouse --wheel-lines=3 ";

--- a/common/modules/user-env/env/direnv.nix
+++ b/common/modules/user-env/env/direnv.nix
@@ -1,12 +1,16 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  };
 in
 {
   config = lib.mkIf cfg.enable {
     home-manager.users."${cfg.username}" = {
       programs.direnv.enable = true;
+      programs.direnv.package = pkgsUnstable.direnv;
       # A faster, persistent implementation of direnv's use_nix and use_flake,
       # to replace the built-in one from "direnv".
       # https://github.com/nix-community/nix-direnv

--- a/common/modules/user-env/programs/cli/default.nix
+++ b/common/modules/user-env/programs/cli/default.nix
@@ -99,6 +99,7 @@ in
           micro
           minicom # for USB serial: "sudo minicom -D /dev/ttyUSB0"
           nflz
+          nixfmt-rfc-style
           nodejs
           ookla-speedtest
           ouch # cool convenient (de)compression tool

--- a/common/modules/user-env/programs/cli/default.nix
+++ b/common/modules/user-env/programs/cli/default.nix
@@ -1,9 +1,9 @@
 # Some inputs refers to flake inputs.
-{ config, lib, pkgs, nixpkgs-unstable, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
-  pkgsUnstable = import nixpkgs-unstable {
+  pkgsUnstable = import inputs.nixpkgs-unstable {
     system = pkgs.system;
     config = {
       allowUnfree = true;
@@ -57,19 +57,19 @@ in
 
     users.users."${cfg.username}".packages =
       (
-        with pkgs; [
+        with pkgs.phip1611.packages; [
           # All my custom packages that are not too size-intensive and should
           # not live behind any special feature gate.
-          pkgs.phip1611.packages.clion-exclude-direnv
-          pkgs.phip1611.packages.colortest
-          pkgs.phip1611.packages.ddns-update
-          pkgs.phip1611.packages.ftp-backup
-          pkgs.phip1611.packages.keep-directory-diff
-          pkgs.phip1611.packages.link-to-copy
-          pkgs.phip1611.packages.nix-shell-init
-          pkgs.phip1611.packages.normalize-file-permissions
-          pkgs.phip1611.packages.strace-with-colors
-
+          clion-exclude-direnv
+          colortest
+          ddns-update
+          ftp-backup
+          keep-directory-diff
+          link-to-copy
+          nix-shell-init
+          normalize-file-permissions
+          strace-with-colors
+        ] ++ (with pkgsUnstable; [
           ansi
           bat
           bottom
@@ -83,7 +83,7 @@ in
           fd # better find
           file
           git
-          pkgsUnstable.gitlab-timelogs
+          gitlab-timelogs
           grub2 # for grub-file
           hexyl # hex viewer
           httpie
@@ -104,7 +104,6 @@ in
           ouch # cool convenient (de)compression tool
           paging-calculator
           pciutils # lspci
-          # pkg-config # Not really working globally. Use per-project!
           poppler_utils # for pdfunite
           python3Toolchain
           ripgrep
@@ -116,7 +115,7 @@ in
           traceroute
           tree
           ttfb
-          pkgsUnstable.typos
+          typos
           unzip
           usbutils # lsusb
           util-linux # lsblk and more
@@ -129,12 +128,12 @@ in
           zip
           zsh
           zx
-        ]
+        ])
         # Dedicated feature-gate as sometimes, build problems with fresh
         # (or old) kernels occur.
         ++ lib.optional cfg.withPerf config.boot.kernelPackages.perf
         # Don't waste disk space when not needed.
-        ++ lib.optionals cfg.withPkgsJ4F (with pkgs; [
+        ++ lib.optionals cfg.withPkgsJ4F (with pkgsUnstable; [
           cmatrix
           cowsay
           fortune
@@ -143,11 +142,11 @@ in
         ])
         # Especially QEMU comes with 1+ GiB of additional dependencies, so it is
         # smart to feature-gate it.
-        ++ lib.optionals cfg.withVmms (with pkgs; [
+        ++ lib.optionals cfg.withVmms (with pkgsUnstable; [
           pkgs.phip1611.packages.qemu-uefi
           pkgs.phip1611.packages.run-efi
 
-          pkgsUnstable.cloud-hypervisor
+          cloud-hypervisor
           qemu
         ])
       );

--- a/common/modules/user-env/programs/cli/git.nix
+++ b/common/modules/user-env/programs/cli/git.nix
@@ -1,7 +1,10 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  };
 in
 {
   options.phip1611.common.user-env = {
@@ -22,6 +25,7 @@ in
     home-manager.users."${cfg.username}" = {
       programs.git = {
         enable = true;
+        package = pkgsUnstable.git;
         userName = cfg.git.username;
         userEmail = cfg.git.email;
         aliases = {
@@ -39,7 +43,7 @@ in
         ];
         extraConfig = {
           core = {
-            editor = "${pkgs.micro}/bin/micro";
+            editor = "micro";
           };
           pull = {
             rebase = true;

--- a/common/modules/user-env/programs/cli/micro.nix
+++ b/common/modules/user-env/programs/cli/micro.nix
@@ -2,6 +2,9 @@
 
 let
   cfg = config.phip1611.common.user-env;
+  /* pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  }; */
 
   # List here anything from `$ micro -plugin available`
   # TODO: remove this hacky workaround:
@@ -17,7 +20,10 @@ in
       { config, lib, ... }: {
         # TODO somehow add the ".editorconfig" plugin:
         # https://github.com/10sr/editorconfig-micro
+
         programs.micro.enable = true;
+        # TODO only in  home-manager >= 24.11
+        #programs.micro.package = pkgsUnstable.micro;
         programs.micro.settings = {
           colorcolumn = 80;
           colorscheme = "material-tc";

--- a/common/modules/user-env/programs/cli/zsh.nix
+++ b/common/modules/user-env/programs/cli/zsh.nix
@@ -1,7 +1,10 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  };
 in
 {
   config = lib.mkIf cfg.enable {
@@ -16,6 +19,7 @@ in
 
       programs.zsh = {
         enable = true;
+        package = pkgsUnstable.zsh;
 
         # Context:
         # - https://www.soberkoder.com/better-zsh-history/

--- a/common/modules/user-env/programs/dev.nix
+++ b/common/modules/user-env/programs/dev.nix
@@ -2,17 +2,17 @@
 
 let
   cfg = config.phip1611.common.user-env;
-  python3Toolchain = import ./python3-toolchain.nix { inherit pkgs; };
   pkgsUnstable = import inputs.nixpkgs-unstable {
     system = pkgs.system;
   };
+  python3Toolchain = import ./python3-toolchain.nix { pkgs = pkgsUnstable; };
 in
 {
   config = lib.mkIf cfg.enable (lib.mkMerge [
     (
       lib.mkIf cfg.withDevJava {
         users.users."${cfg.username}".packages = (
-          with pkgs; [
+          with pkgsUnstable; [
             jdk
             maven # TODO, JDK might be not needed, as the maven derivation
             # already comes with a JDK.
@@ -23,7 +23,7 @@ in
     (
       lib.mkIf cfg.withDevJavascript {
         users.users."${cfg.username}".packages = (
-          with pkgs; [
+          with pkgsUnstable; [
             nodejs
             yarn
           ]
@@ -33,7 +33,7 @@ in
     (
       lib.mkIf cfg.withDevNix {
         users.users."${cfg.username}".packages = (
-          with pkgs; [
+          with pkgsUnstable; [
             deadnix
             niv
             nixpkgs-fmt
@@ -47,7 +47,7 @@ in
     (
       lib.mkIf cfg.withDevCAndRust {
         users.users."${cfg.username}".packages = (
-          with pkgs; [
+          with pkgsUnstable; [
             gcc
             # already there automatically; here only for completeness
             binutils
@@ -65,7 +65,7 @@ in
     (
       lib.mkIf cfg.withDevCAndRust {
         users.users."${cfg.username}".packages = (
-          with pkgs; [
+          with pkgsUnstable; [
             cargo-deny
             cargo-expand
             cargo-license
@@ -78,7 +78,7 @@ in
 
             # Rustup can't auto-update itself but manage installed Rust
             # toolchains.
-            pkgsUnstable.rustup
+            rustup
           ]
         );
       }
@@ -90,7 +90,7 @@ in
           # out-of-tree modules right from the shell.
           (pkgs.buildFHSEnv {
             name = "legacy-env";
-            targetPkgs = pkgs: with pkgs; [
+            targetPkgs = _pkgs: with pkgsUnstable; [
               acpica-tools
               bc
               binutils

--- a/common/modules/user-env/programs/gui/alacritty.nix
+++ b/common/modules/user-env/programs/gui/alacritty.nix
@@ -1,14 +1,10 @@
-{ config, lib, pkgs, nixpkgs-unstable, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
-  pkgsUnstable = import nixpkgs-unstable {
+  pkgsUnstable = import inputs.nixpkgs-unstable {
     system = pkgs.system;
-    config = {
-      allowUnfree = true;
-    };
   };
-  alacritty = pkgsUnstable.alacritty;
 in
 {
   config = lib.mkIf (cfg.enable && cfg.withGui) {
@@ -20,7 +16,7 @@ in
     home-manager.users."${cfg.username}" = {
       programs.alacritty = {
         enable = true;
-        package = alacritty;
+        package = pkgsUnstable.alacritty;
         settings = builtins.fromTOML (builtins.readFile ./alacritty.toml);
       };
     };

--- a/common/modules/user-env/programs/gui/default.nix
+++ b/common/modules/user-env/programs/gui/default.nix
@@ -1,8 +1,8 @@
-{ config, lib, pkgs, nixpkgs-unstable, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
-  pkgsUnstable = import nixpkgs-unstable {
+  pkgsUnstable = import inputs.nixpkgs-unstable {
     system = pkgs.system;
     config = {
       allowUnfree = true;
@@ -22,7 +22,7 @@ in
     services.teamviewer.enable = true;
 
     users.users."${cfg.username}".packages = (
-      with pkgs; [
+      with pkgsUnstable; [
         _1password-gui
         drawio
         gimp
@@ -52,7 +52,7 @@ in
       )
     ) ++ (
       lib.optionals cfg.withMedia (
-        with pkgs; [
+        with pkgsUnstable; [
           audacity
         ]
       )

--- a/common/modules/user-env/programs/gui/teamviewer.nix
+++ b/common/modules/user-env/programs/gui/teamviewer.nix
@@ -1,21 +1,17 @@
-{ config, lib, pkgs, ... }@inputs:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.phip1611.common.user-env;
-  pkgsUnstable = import inputs.nixpkgs-unstable {
-    system = pkgs.system;
-    config = {
-      allowUnfree = true;
-    };
-  };
 in
 {
   config = lib.mkIf (cfg.enable && cfg.withGui) {
     # Teamviewer GUI doesn't work without the daemon.
     services.teamviewer.enable = true;
+    # Wait for https://github.com/NixOS/nixpkgs/pull/346365
+    # services.teamviewer.package = pkgsUnstable.teamviewer;
 
     users.users."${cfg.username}".packages = [
-      pkgsUnstable.teamviewer
+      pkgs.teamviewer
     ];
   };
 }

--- a/common/modules/user-env/programs/gui/teamviewer.nix
+++ b/common/modules/user-env/programs/gui/teamviewer.nix
@@ -1,15 +1,21 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+    config = {
+      allowUnfree = true;
+    };
+  };
 in
 {
   config = lib.mkIf (cfg.enable && cfg.withGui) {
     # Teamviewer GUI doesn't work without the daemon.
     services.teamviewer.enable = true;
 
-    users.users."${cfg.username}".packages = (with pkgs; [
-      teamviewer
-    ]);
+    users.users."${cfg.username}".packages = [
+      pkgsUnstable.teamviewer
+    ];
   };
 }

--- a/common/modules/user-env/programs/gui/vscode.nix
+++ b/common/modules/user-env/programs/gui/vscode.nix
@@ -1,18 +1,16 @@
-{ config, lib, pkgs, nixpkgs-unstable, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
-  pkgsUnstable = import nixpkgs-unstable {
+  pkgsUnstable = import inputs.nixpkgs-unstable {
     system = pkgs.system;
     config = {
       allowUnfree = true;
     };
   };
-  vscode = pkgsUnstable.vscode;
 in
 {
   config = lib.mkIf (cfg.enable && cfg.withGui) {
-
     fonts.packages = with pkgs; [
       source-code-pro
     ];
@@ -20,7 +18,7 @@ in
     home-manager.users."${cfg.username}" = {
       programs.vscode = {
         enable = true;
-        package = vscode;
+        package = pkgsUnstable.vscode;
         extensions = with pkgs.vscode-extensions; [
           bbenoist.nix
           tamasfe.even-better-toml

--- a/common/modules/user-env/programs/media.nix
+++ b/common/modules/user-env/programs/media.nix
@@ -1,15 +1,18 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
 let
   cfg = config.phip1611.common.user-env;
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  };
 in
 {
   config = lib.mkIf (cfg.enable && cfg.withMedia) {
     users.users."${cfg.username}".packages = (
-      with pkgs; [
+      with pkgsUnstable; [
         exiftool
         ffmpeg
-        jhead # `jheda -ft *` is very cool!
+        jhead # `jhead -ft *` is very cool to view EFIF data!
         imagemagick
         libwebp # webp encoder
       ]

--- a/hosts/asking-alexandria/web-services/nginx.nix
+++ b/hosts/asking-alexandria/web-services/nginx.nix
@@ -1,5 +1,10 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@inputs:
 
+let
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  };
+in
 {
   networking.firewall = {
     enable = true;
@@ -12,7 +17,7 @@
   users.users.nginx.extraGroups = [ "acme" ];
 
   services.nginx.enable = true;
-  services.nginx.package = pkgs.nginxQuic;
+  services.nginx.package = pkgsUnstable.nginxQuic;
 
   services.nginx.recommendedOptimisation = true;
   services.nginx.recommendedTlsSettings = true;


### PR DESCRIPTION
Consume every extra package from pkgsUnstable to have the freshest version available. The NixOS system itself will still be build from stable, including all system services. But all additional user software (CLI tools, GUIs) are now use the bleeding-edge versions from upstream.

This helps me to keep up-to-date. Some packages for example do not get backported to the latest release.

The risk I introduce here is negligible, I think. It might happen that sometimes software is broken. But I still can switch back easily.