### PR TITLE
modules(common,system): add secure DNS to my NixOS systems (DNSSEC, DNS OVER TLS) 

### DIFF
--- a/common/modules/system/default.nix
+++ b/common/modules/system/default.nix
@@ -20,6 +20,7 @@ in
     ./networking.nix
     ./nix-cfg.nix
     ./nix-path-from-flake.nix
+    ./secure-dns.nix
   ];
 
   options = {
@@ -29,6 +30,7 @@ in
       withAutoUpgrade = lib.mkEnableOption "Enable automatic system upgrades from this flake on GitHub";
       withBleedingEdgeLinux = lib.mkEnableOption "Enable bleeding edge Linux version and configs";
       withDocker = lib.mkEnableOption "Enable (rootless) docker";
+      withSecureDns = lib.mkEnableOption "Enable secure DNS (DNSSec, DoH, DoT)";
     };
   };
 

--- a/common/modules/system/secure-dns.nix
+++ b/common/modules/system/secure-dns.nix
@@ -1,0 +1,69 @@
+# Secure DNS: System-wide DNSSEC + DNS over HTTPS (DOH)
+# Reference: https://nixos.wiki/wiki/Encrypted_DNS
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.phip1611.common.system;
+in
+{
+  config = lib.mkIf cfg.enable {
+    # Wait for https://github.com/NixOS/nixpkgs/pull/377577 to be resolved
+    networking.nameservers = lib.mkForce [ "127.0.0.1" ];
+
+    # Establishes a local DNS proxy that supports various DNS encryption
+    # protocols in background. Among them are DNSSEC and DNS over HTTPS (DOH).
+    # This proxy will act as system-wide DNS-server. It depends on the DNS
+    # server being used in backend whether DNSSEC and DoH, are actually used.
+    # See server list!
+    #
+    # This works with and without systemd-resolved and systemd-networkd, as well
+    # as with or without Tailscale DNS.
+    #
+    # Some interesting technical background info about DNS resolving on todays
+    # Linux systems can be found here:
+    # https://tailscale.com/blog/sisyphean-dns-client-linux
+    services.dnscrypt-proxy2 = {
+      enable = true;
+      # Settings reference:
+      # https://github.com/DNSCrypt/dnscrypt-proxy/blob/master/dnscrypt-proxy/example-dnscrypt-proxy.toml
+      settings = {
+        ipv4_servers = true;
+        ipv6_servers = true;
+        require_dnssec = true;
+
+        sources.public-resolvers = {
+          urls = [
+            "https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/public-resolvers.md"
+            "https://download.dnscrypt.info/resolvers-list/v3/public-resolvers.md"
+          ];
+          cache_file = "/var/lib/dnscrypt-proxy2/public-resolvers.md";
+          minisign_key = "RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3";
+        };
+        # List chosen from. dnscrypt-proxy2 will sort this by latency but also
+        # rotate the DNS servers to improve privacy.
+        # https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v3/public-resolvers.md
+        server_names = [
+          # German entity
+          "artikel10-doh-ipv4"
+          "artikel10-doh-ipv6"
+
+          # Switzern entity, (some?) servers in Germany
+          "quad9-doh-ip4-port443-nofilter-pri"
+          "quad9-doh-ip6-port443-nofilter-pri"
+
+          "cloudflare"
+          "cloudflare-ipv6"
+
+          "google"
+          "google-ipv6"
+        ];
+      };
+    };
+  };
+}

--- a/common/modules/system/secure-dns.nix
+++ b/common/modules/system/secure-dns.nix
@@ -56,12 +56,6 @@ in
           # Switzern entity, (some?) servers in Germany
           "quad9-doh-ip4-port443-nofilter-pri"
           "quad9-doh-ip6-port443-nofilter-pri"
-
-          "cloudflare"
-          "cloudflare-ipv6"
-
-          "google"
-          "google-ipv6"
         ];
       };
     };

--- a/profiles/dev-machine.nix
+++ b/profiles/dev-machine.nix
@@ -31,6 +31,7 @@
           enable = lib.mkDefault true;
           withBleedingEdgeLinux = lib.mkDefault true;
           withDocker = lib.mkDefault true;
+          withSecureDns = lib.mkDefault true;
         };
       };
       nix-binary-cache.enable = lib.mkDefault true;

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -28,6 +28,7 @@
           # 6.11, everything is fine.
           # TODO: Go back to LTS 6.12, once it is released!
           withBleedingEdgeLinux = lib.mkDefault true;
+          withSecureDns = lib.mkDefault true;
         };
       };
       nix-binary-cache.enable = lib.mkDefault true;


### PR DESCRIPTION
modules(common,system): add secure DNS

This commit brings the goodness of modern encrypted DNS onto my
NixOS hosts.

It adds a local DNS proxy that forwards DNS requests to one of a list
of configured servers using a (conjunction of) secure DNS protocol(s).
Depending on the capabilities of the used DNS server behind the scenes,
DNSSec and DoH will actually be used! Hence, those servers need to be
chosen wisely ;) A list is provided upstream.

Luckily, dnscrypt-proxy also works with (and without) systemd-networkd,
systemd-resolved, and even Tailscale.

From my testing, such as looking at the query log [0] and monitoring
the interfaces, I am sure that indeed DoH (DNS over HTTPS) is used.
Also, I observed that the DNS servers from the list are rotated.
Nice! I also verified by using various "DNS leakage" tests
found on the web - success!

[0] /var/log/dnscrypt-proxy/query.log