### PR TITLE
build-all-configs.sh: also populate Nix binary cache

### DIFF
--- a/build-all-configs.sh
+++ b/build-all-configs.sh
@@ -4,6 +4,32 @@
 
 set -euo pipefail
 
-nix flake show --json 2>/dev/null | jq '.nixosConfigurations | keys[]' | xargs -I {} bash -c "echo 'building NixOS system {}:'; nix build .#nixosConfigurations.{}.config.system.build.toplevel"
+binary_cache_host=phip1611.dev
+binary_cache_user=phip1611
+binary_cache_ssh_port=7331
+
+# Helper for `fn_build_nixos_system`
+_fn_build_nixos_system() {
+  system=$1
+
+  echo "Building NixOS system $system ..."
+  nix build ".#nixosConfigurations.$system.config.system.build.toplevel"
+  echo "✔️ Successfully built NixOS system $system"
+
+  echo "Populating the Nix binary cache at $binary_cache_host"
+  NIX_SSHOPTS="-p $binary_cache_ssh_port" nix-copy-closure --to $binary_cache_user@$binary_cache_host result
+  echo "✔️ Populated the Nix binary cache at $binary_cache_host"
+}
+
+# Reads the NixOS systems it should build line by line from stdin and performs
+# the actual action.
+fn_build_nixos_system() {
+  # read all lines in lines array
+  while IFS= read -r line; do
+      _fn_build_nixos_system "$line"
+  done
+}
+
+nix flake show --json 2>/dev/null | jq -r '.nixosConfigurations | keys[]' | fn_build_nixos_system
 
 rm -rf ./result


### PR DESCRIPTION
This brings the benefit that local builds also populate my Nix binary cache. Less wasted CPU time! Otherwise, only the GitHub CI populated the cache so far.