### PR TITLE
zsh history backup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: |
-          nix fmt
-          # Since there is no "nix fmt --check", we use the workaround and see
-          # if git files have been changed.
-          git diff --quiet
+      - name: Check Nix formatting
+        run: |
+          set +e
+          # "nixfmt" doesn't has a nice diff output for its `--check` command, therefore
+          # we use `git diff`
+          find . -name "*.nix" -type f -exec nix fmt {} \+
+
+          # Show format diff
+          git --no-pager diff
+
+          # Report error, fail pipeline job
+          set -e
+          git --no-pager diff --quiet
 
   # TODO make more fine-grained once https://github.com/NixOS/nix/issues/9629 is
   # solved.

--- a/common/modules/services/ddns-update.nix
+++ b/common/modules/services/ddns-update.nix
@@ -31,7 +31,7 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable ({
+  config = lib.mkIf cfg.enable {
     systemd.services.ddns-update = {
       enable = true;
       description = "ddns-update service";
@@ -48,6 +48,6 @@ in
         Unit = "ddns-update.service";
       };
     };
-  });
+  };
 
 }

--- a/common/modules/services/ddns-update.nix
+++ b/common/modules/services/ddns-update.nix
@@ -9,6 +9,8 @@
 
 let
   cfg = config.phip1611.services.ddns-update;
+  # Get package from overlay.
+  pkg = pkgs.phip1611.packages.ddns-update;
 in
 {
   options.phip1611.services.ddns-update = {
@@ -33,18 +35,9 @@ in
     systemd.services.ddns-update = {
       enable = true;
       description = "ddns-update service";
-      script =
-        let
-          ddns-update = pkgs.phip1611.packages.ddns-update;
-        in
-        ''
-          set -euo pipefail
-          # Yes, this could be a single "curl -u user:pass host" but I don't want
-          # to leak any credentials into the Nix store.
-          ${ddns-update}/bin/ddns-update --config ${cfg.configPath}
-        '';
       serviceConfig = {
         Type = "oneshot";
+        ExecStart = "${lib.getExe pkg} --config ${cfg.configPath}";
       };
     };
     systemd.timers.ddns-update = {

--- a/common/modules/services/default.nix
+++ b/common/modules/services/default.nix
@@ -13,5 +13,6 @@
   imports = [
     ./ddns-update.nix
     ./meshcommander.nix
+    ./zsh-history-backup.nix
   ];
 }

--- a/common/modules/services/zsh-history-backup.nix
+++ b/common/modules/services/zsh-history-backup.nix
@@ -18,14 +18,14 @@ in
     intervalMinutes = lib.mkOption {
       type = lib.types.int;
       description = "Interval in minutes for the service to run.";
-      default = 60 # once per hour
-      ;
-      example = 60 # once per hour
-      ;
+      # once per hour
+      default = 60;
+      # once per hour
+      example = 60;
     };
   };
 
-  config = lib.mkIf cfg.enable ({
+  config = lib.mkIf cfg.enable {
     systemd.user.services.zsh-history-backup = {
       enable = true;
       description = "zsh-history-backup (per-user) service";
@@ -42,6 +42,6 @@ in
         Unit = "zsh-history-backup.service";
       };
     };
-  });
+  };
 
 }

--- a/common/modules/services/zsh-history-backup.nix
+++ b/common/modules/services/zsh-history-backup.nix
@@ -1,0 +1,47 @@
+# zsh-history-backup systemd user service for every user on the system.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.phip1611.services.zsh-history-backup;
+  # Get package from overlay.
+  pkg = pkgs.phip1611.packages.zsh-history-backup;
+in
+{
+  options.phip1611.services.zsh-history-backup = {
+    enable = lib.mkEnableOption "Enable a regularly scheduled backup of your `zsh` history`";
+    intervalMinutes = lib.mkOption {
+      type = lib.types.int;
+      description = "Interval in minutes for the service to run.";
+      default = 60 # once per hour
+      ;
+      example = 60 # once per hour
+      ;
+    };
+  };
+
+  config = lib.mkIf cfg.enable ({
+    systemd.user.services.zsh-history-backup = {
+      enable = true;
+      description = "zsh-history-backup (per-user) service";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${lib.getExe pkg}";
+      };
+    };
+    systemd.user.timers.zsh-history-backup-update = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "0m";
+        OnUnitActiveSec = "${toString cfg.intervalMinutes}m";
+        Unit = "zsh-history-backup.service";
+      };
+    };
+  });
+
+}

--- a/common/modules/user-env/programs/cli/default.nix
+++ b/common/modules/user-env/programs/cli/default.nix
@@ -76,6 +76,7 @@ in
         normalize-file-permissions
         strace-with-colors
         wait-host-online
+        zsh-history-backup
       ]
       ++ (with pkgsUnstable; [
         ansi

--- a/common/modules/user-env/programs/cli/zsh.nix
+++ b/common/modules/user-env/programs/cli/zsh.nix
@@ -15,6 +15,9 @@ in
   config = lib.mkIf cfg.enable {
     # Adds zsh to PATH and to /etc/shells and link /share/zsh for completions.
     programs.zsh.enable = true;
+    programs.zsh.shellAliases = {
+      save-zsh-history = "fc -W";
+    };
 
     home-manager.users."${cfg.username}" = {
       home.sessionVariables = {
@@ -29,26 +32,34 @@ in
         # Context:
         # - https://www.soberkoder.com/better-zsh-history/
         # - https://zsh.sourceforge.io/Doc/Release/Options.html
+        # - https://zsh.sourceforge.io/Doc/Release/Parameters.html
         history =
           let
             # Default is 10000.
             saveLines = 200000; # This results in roughly 1-6 MiB memory usage.
           in
           {
+            # EXTENDED_HISTORY
             # Save timestamp into the history file.
             extended = true;
-            # If a new command line being added to the history list duplicates
-            # an older one, the older command is removed from the list (even if
-            # it is not the previous event).
-            ignoreAllDups = true;
-            ignoreDups = true; # TODO Reevaluate once the option above is used.
+            # HIST_IGNORE_DUPS
+            # Don't push commands to the history if they are a duplicate of the
+            # previous command.
+            ignoreDups = true;
+            # HIST_IGNORE_ALL_DUPS
+            # Don't remove old duplicates (not previous command) from history.
+            ignoreAllDups = false;
+            # HIST_IGNORE_SPACE
             # Do not enter command lines into the history list if the first
             # character is a space.
             ignoreSpace = true;
-            # Number of history lines to save.
+            # SAVEHIST
+            # Number of history lines to save on disk.
             save = saveLines;
+            # HISTSIZE
             # Number of history lines to load into memory.
             size = saveLines;
+            # SHARE_HISTORY
             # Share command history between zsh sessions. This also adds new
             # commands to the history as they are typed. Hence, this is more
             # powerful than INC_APPEND_HISTORY.

--- a/common/nix/packages/clion-exclude-direnv/default.nix
+++ b/common/nix/packages/clion-exclude-direnv/default.nix
@@ -3,12 +3,17 @@
 # [0] https://youtrack.jetbrains.com/issue/CPP-39605/CLion-Always-allow-Mark-Directory-as-Excluded-not-a-CMake-Project
 # [1] https://youtrack.jetbrains.com/issue/CPP-13494/Mark-Directory-as-Excluded-should-be-available-even-when-CMake-is-not-loaded
 
-{ pkgs }:
+{
+  lib,
+  writeShellScriptBin,
 
-let
-  lib = pkgs.lib;
-in
-pkgs.writeShellScriptBin "clion-exclude-direnv" ''
+  # runtime deps
+  argc,
+  fd,
+  python3Minimal,
+}:
+
+writeShellScriptBin "clion-exclude-direnv" ''
   # The following @-annotations belong to https://github.com/sigoden/argc
   #
   # @describe
@@ -19,14 +24,11 @@ pkgs.writeShellScriptBin "clion-exclude-direnv" ''
   set -euo pipefail
 
   export PATH="${
-    lib.makeBinPath (
-      with pkgs;
-      [
-        argc
-        fd
-        python3Minimal
-      ]
-    )
+    lib.makeBinPath ([
+      argc
+      fd
+      python3Minimal
+    ])
   }:$PATH"
 
   # Do the "argc" magic. Reference: https://github.com/sigoden/argc

--- a/common/nix/packages/ddns-update/default.nix
+++ b/common/nix/packages/ddns-update/default.nix
@@ -11,7 +11,6 @@
 }:
 
 let
-  src = ./.;
   deps = [
     argc
     ansi
@@ -22,12 +21,14 @@ in
 runCommand "ddns-update"
   {
     nativeBuildInputs = [ makeWrapper ];
+    meta = {
+      mainProgram = "ddns-update";
+    };
   }
   ''
     mkdir -p $out/bin
-    install -m +x ${src}/ddns-update.sh $out/bin/ddns-update
+    install -m +x ${./ddns-update.sh} $out/bin/ddns-update
 
     wrapProgram $out/bin/ddns-update \
-      --inherit-argv0 \
       --prefix PATH : ${lib.makeBinPath deps}
   ''

--- a/common/nix/packages/ddns-update/default.nix
+++ b/common/nix/packages/ddns-update/default.nix
@@ -6,6 +6,7 @@
   # runtime deps
   argc,
   ansi,
+  bash,
   curl,
   jq,
 }:
@@ -14,6 +15,7 @@ let
   deps = [
     argc
     ansi
+    bash
     curl
     jq
   ];

--- a/common/nix/packages/ftp-backup/default.nix
+++ b/common/nix/packages/ftp-backup/default.nix
@@ -25,13 +25,15 @@ let
     runCommand "ftp-backup"
       {
         nativeBuildInputs = [ makeWrapper ];
+        meta = {
+          mainProgram = "ftp-backup";
+        };
       }
       ''
         mkdir -p $out/bin
         install -m +x ${./ftp-backup.sh} $out/bin/ftp-backup
 
         wrapProgram $out/bin/ftp-backup \
-          --inherit-argv0 \
           --prefix PATH : ${lib.makeBinPath shellScriptDeps}
       '';
 
@@ -43,13 +45,15 @@ let
     runCommand "ftp-backup-from-config"
       {
         nativeBuildInputs = [ makeWrapper ];
+        meta = {
+          mainProgram = "ftp-backup-from-config";
+        };
       }
       ''
         mkdir -p $out/bin
         install -m +x ${./ftp-backup-from-config.py} $out/bin/ftp-backup-from-config
 
         wrapProgram $out/bin/ftp-backup-from-config \
-          --inherit-argv0 \
           --prefix PATH : ${lib.makeBinPath pythonScriptDeps}
       '';
 in

--- a/common/nix/packages/ftp-backup/default.nix
+++ b/common/nix/packages/ftp-backup/default.nix
@@ -7,6 +7,7 @@
   # runtime deps
   ansi,
   argc,
+  bash,
   gnutar,
   lftp,
   zstd,
@@ -17,6 +18,7 @@ let
   shellScriptDeps = [
     ansi
     argc
+    bash
     gnutar
     lftp
     zstd

--- a/common/nix/packages/keep-directory-diff/default.nix
+++ b/common/nix/packages/keep-directory-diff/default.nix
@@ -2,11 +2,12 @@
 # nix develop --command bash -c 'rm -rf dir1 dir2 && mkdir dir1 && echo "hello" > dir1/hello.txt && echo "hello2" > dir1/hello2.txt && cp -r dir1 dir2 && cp dir2/hello.txt dir2/hello3.txt && echo "foobar" > dir2/hello.txt && keep-directory-diff dir1 dir2'
 
 {
+  lib,
+  writeShellScriptBin,
+  # runtime deps
   ansi,
   argc,
   fd,
-  lib,
-  writeShellScriptBin,
 }:
 
 writeShellScriptBin "keep-directory-diff" ''

--- a/common/nix/packages/link-to-copy/default.nix
+++ b/common/nix/packages/link-to-copy/default.nix
@@ -6,12 +6,14 @@
   # runtime deps
   ansi,
   argc,
+  bash,
 }:
 
 let
   deps = [
     ansi
     argc
+    bash
   ];
 in
 runCommand "link-to-copy"

--- a/common/nix/packages/link-to-copy/default.nix
+++ b/common/nix/packages/link-to-copy/default.nix
@@ -9,7 +9,6 @@
 }:
 
 let
-  src = ./.;
   deps = [
     ansi
     argc
@@ -18,12 +17,14 @@ in
 runCommand "link-to-copy"
   {
     nativeBuildInputs = [ makeWrapper ];
+    meta = {
+      mainProgram = "link-to-copy";
+    };
   }
   ''
     mkdir -p $out/bin
-    install -m +x ${src}/link-to-copy.sh $out/bin/link-to-copy
+    install -m +x ${./link-to-copy.sh} $out/bin/link-to-copy
 
     wrapProgram $out/bin/link-to-copy \
-      --inherit-argv0 \
       --prefix PATH : ${lib.makeBinPath deps}
   ''

--- a/common/nix/packages/normalize-file-permissions/default.nix
+++ b/common/nix/packages/normalize-file-permissions/default.nix
@@ -5,10 +5,14 @@
 
   # runtime deps
   argc,
+  bash,
 }:
 
 let
-  deps = [ argc ];
+  deps = [
+    argc
+    bash
+  ];
 in
 runCommand "normalize-file-permissions"
   {

--- a/common/nix/packages/normalize-file-permissions/default.nix
+++ b/common/nix/packages/normalize-file-permissions/default.nix
@@ -8,18 +8,19 @@
 }:
 
 let
-  src = ./.;
   deps = [ argc ];
 in
 runCommand "normalize-file-permissions"
   {
     nativeBuildInputs = [ makeWrapper ];
+    meta = {
+      mainProgram = "normalize-file-permissions";
+    };
   }
   ''
     mkdir -p $out/bin
-    install -m +x ${src}/normalize-file-permissions.sh $out/bin/normalize-file-permissions
+    install -m +x ${./normalize-file-permissions.sh} $out/bin/normalize-file-permissions
 
     wrapProgram $out/bin/normalize-file-permissions \
-      --inherit-argv0 \
       --prefix PATH : ${lib.makeBinPath deps}
   ''

--- a/common/nix/packages/run-efi/default.nix
+++ b/common/nix/packages/run-efi/default.nix
@@ -1,10 +1,11 @@
 {
+  lib,
+  writeShellScriptBin,
+  OVMF,
+  # runtime deps
   ansi,
   argc,
-  lib,
-  OVMF,
   qemu,
-  writeShellScriptBin,
 }:
 
 writeShellScriptBin "run-efi" ''

--- a/common/nix/packages/strace-with-colors/default.nix
+++ b/common/nix/packages/strace-with-colors/default.nix
@@ -5,8 +5,6 @@ let
     sha256 = "sha256:1rgghm9knxhiw1m8sw0nim7x3qdd476d6sx83x0p3s6pc7fns3y4";
   };
   straceWithPatch = strace.overrideAttrs {
-    # TODO remove once https://github.com/NixOS/nixpkgs/pull/345436 is merged
-    enableParallelBuilding = true;
     patches = [
       ("${colorPatchSrc}/strace-with-colors.patch")
     ];

--- a/common/nix/packages/wait-host-online/default.nix
+++ b/common/nix/packages/wait-host-online/default.nix
@@ -6,18 +6,19 @@
 }:
 
 let
-  src = ./.;
   deps = [ argc ];
 in
 runCommand "wait-host-online"
   {
     nativeBuildInputs = [ makeWrapper ];
+    meta = {
+      mainProgram = "wait-host-online";
+    };
   }
   ''
     mkdir -p $out/bin
-    install -m +x ${src}/wait-host-online.sh $out/bin/wait-host-online
+    install -m +x ${./wait-host-online.sh} $out/bin/wait-host-online
 
     wrapProgram $out/bin/wait-host-online \
-      --inherit-argv0 \
       --prefix PATH : ${lib.makeBinPath deps}
   ''

--- a/common/nix/packages/wait-host-online/default.nix
+++ b/common/nix/packages/wait-host-online/default.nix
@@ -1,12 +1,17 @@
 {
-  argc,
   lib,
   makeWrapper,
   runCommand,
+  # runtime deps
+  argc,
+  bash,
 }:
 
 let
-  deps = [ argc ];
+  deps = [
+    argc
+    bash
+  ];
 in
 runCommand "wait-host-online"
   {

--- a/common/nix/packages/zsh-history-backup/default.nix
+++ b/common/nix/packages/zsh-history-backup/default.nix
@@ -3,12 +3,14 @@
   makeWrapper,
   runCommand,
   # runtime deps
+  bash,
   zsh,
   zstd,
 }:
 
 let
   deps = [
+    bash
     zsh
     zstd
   ];

--- a/common/nix/packages/zsh-history-backup/default.nix
+++ b/common/nix/packages/zsh-history-backup/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  makeWrapper,
+  runCommand,
+  # runtime deps
+  zsh,
+  zstd,
+}:
+
+let
+  deps = [
+    zsh
+    zstd
+  ];
+in
+runCommand "zsh-history-backup"
+  {
+    nativeBuildInputs = [ makeWrapper ];
+    meta = {
+      mainProgram = "zsh-history-backup";
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    install -m +x ${./zsh-history-backup.sh} $out/bin/zsh-history-backup
+
+    wrapProgram $out/bin/zsh-history-backup \
+      --prefix PATH : ${lib.makeBinPath deps}
+  ''

--- a/common/nix/packages/zsh-history-backup/zsh-history-backup.sh
+++ b/common/nix/packages/zsh-history-backup/zsh-history-backup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# This script backups `~/.zsh_history` to `~/.zsh_history.backup` or restores it
+# from there, if necessary.
+#
+# It does so on every invocation. This helps to workaround cases where ZSH
+# suddenly truncates the history file, which I experiences once every ~4-6
+# months.
+#
+# Only new zsh sessions will read the history from the new file, or the history
+# needs to be explicitly imported using the shell built-in `fc`.
+
+set -euo pipefail
+
+# TODO switch to `$(zsh -ic 'echo $HISTFILE')`?
+HIST_FILE="$HOME/.zsh_history"
+BACKUP_FILE="$HIST_FILE.backup"
+
+# Creates a backup file.
+fn_backup_file() {
+  if [ -f "$BACKUP_FILE" ]; then
+    mv "$BACKUP_FILE" "$BACKUP_FILE.old"
+  fi
+  cp "$HIST_FILE" "$BACKUP_FILE"
+  rm -f "$BACKUP_FILE.old"
+}
+
+fn_restore_backup() {
+  rm -f "$HIST_FILE"
+  cp "$BACKUP_FILE" "$HIST_FILE"
+}
+
+# Checks if we need to restore the backup.
+fn_need_restore() {
+  local WAS_TRUNCATED_THRESHOLD=100
+  local RET_NEED_BACKUP_RESTORE=0
+  local RET_NO_BACKUP_RESTORE=1
+  local backup_size=0
+  local current_size=0
+
+  # Get the maximum lines the ZSH history file can have.
+  # We start an interactive shell to ensure that zsh sources all its
+  # configuration files properly.
+  # limit=$(zsh -ic 'echo $SAVEHIST')
+
+  # Check that current file exists.
+  if [ -f "$HIST_FILE" ]; then
+    current_size=$(wc -l < "$HIST_FILE")
+  fi
+
+  # Check that backup file exists.
+  if [ -f "$BACKUP_FILE" ]; then
+    backup_size=$(wc -l < "$BACKUP_FILE")
+  fi
+
+  # We only need to restore the file when the file was truncated.
+  echo "current history size=$current_size"
+  echo "backup history size =$backup_size"
+  if [ "$current_size" -lt "$WAS_TRUNCATED_THRESHOLD" ] && [ "$current_size" -lt "$backup_size" ]; then
+      return "$RET_NEED_BACKUP_RESTORE"
+  else
+      return "$RET_NO_BACKUP_RESTORE"
+  fi
+}
+
+fn_main() {
+  if fn_need_restore; then
+    echo "⚠️ The history files seems to have been truncated; restoring backup"
+    fn_restore_backup
+    echo "✅ Backup restored in '$HIST_FILE'"
+  else
+    echo "✅ Backing up history file '$HIST_FILE' to '$BACKUP_FILE'"
+    if [ -f "$HIST_FILE" ]; then
+      fn_backup_file
+    fi
+  fi
+}
+
+fn_main

--- a/profiles/dev-machine.nix
+++ b/profiles/dev-machine.nix
@@ -35,6 +35,7 @@
         };
       };
       nix-binary-cache.enable = lib.mkDefault true;
+      services.zsh-history-backup.enable = lib.mkDefault true;
     };
 
     nix = {

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -28,6 +28,7 @@
         };
       };
       nix-binary-cache.enable = lib.mkDefault true;
+      services.zsh-history-backup.enable = lib.mkDefault true;
     };
 
     # Latest LTS kernel


### PR DESCRIPTION
This is a solution to mitigate issues I encounter ~once per quarter. Suddenly, the zsh history is deleted. Therefore:

- new `zsh-backup-history` CLI utility on $PATH
- new systemd user service (default: once per hour) backing up the zsh history file (or restoring it)