### PR TITLE
bootitems: makeInitrd => makeInitrdNG

### DIFF
--- a/common/nix/bootitems/linux/build-initrd.nix
+++ b/common/nix/bootitems/linux/build-initrd.nix
@@ -31,6 +31,8 @@
   # }
   # ```
   additionalFiles ? [ ],
+  # Additional initialization bash script.
+  initScript ? "",
 }:
 
 let
@@ -82,6 +84,9 @@ makeInitrd {
             ]
           )
         }
+
+        # Additional aliases, variables, etc.
+        ${initScript}
       '';
     }
     # Set up some typical file-system nodes, create device-nodes.

--- a/common/nix/bootitems/linux/build-initrd.nix
+++ b/common/nix/bootitems/linux/build-initrd.nix
@@ -31,8 +31,6 @@
   # }
   # ```
   additionalFiles ? [ ],
-  # Additional initialization bash script.
-  initScript ? "",
 }:
 
 let
@@ -85,9 +83,6 @@ makeInitrdNG {
             ]
           )
         }
-
-        # Additional aliases, variables, etc.
-        ${initScript}
       '';
     }
     # Set up some typical file-system nodes, create device-nodes.

--- a/common/nix/bootitems/linux/busybox-acpid.nix
+++ b/common/nix/bootitems/linux/busybox-acpid.nix
@@ -63,12 +63,12 @@ in
   inherit setupScript;
   initrdContents = [
     {
-      symlink = "/etc/acpid.conf";
-      object = config;
+      target = "/etc/acpid.conf";
+      source = config;
     }
     {
-      symlink = "/etc/acpi/power";
-      object = powerOffScript;
+      target = "/etc/acpi/power";
+      source = powerOffScript;
     }
   ];
 }

--- a/common/nix/bootitems/linux/default.nix
+++ b/common/nix/bootitems/linux/default.nix
@@ -175,15 +175,6 @@ let
           source = kernels.stable;
         }
       ];
-      initScript = (old.initScript or "") + ''
-        alias run_chv='cloud-hypervisor \
-          --kernel "/etc/bootitems/kernel/bzImage" \
-          --cmdline "console=ttyS0" \
-          --initramfs "/etc/bootitems/initrd/initrd" \
-          --serial "tty" \
-          --console "off" \
-          --memory size=1G'
-      '';
     });
   };
 

--- a/common/nix/bootitems/linux/default.nix
+++ b/common/nix/bootitems/linux/default.nix
@@ -167,12 +167,12 @@ let
       #     --memory size=1G
       additionalFiles = (old.additionalFiles or [ ]) ++ [
         {
-          symlink = "/etc/bootitems/initrd";
-          object = initrds.minimal;
+          target = "/etc/bootitems/initrd";
+          source = initrds.minimal;
         }
         {
-          symlink = "/etc/bootitems/kernel";
-          object = kernels.stable;
+          target = "/etc/bootitems/kernel";
+          source = kernels.stable;
         }
       ];
       initScript = (old.initScript or "") + ''

--- a/common/nix/bootitems/linux/default.nix
+++ b/common/nix/bootitems/linux/default.nix
@@ -175,6 +175,15 @@ let
           object = kernels.stable;
         }
       ];
+      initScript = (old.initScript or "") + ''
+        alias run_chv='cloud-hypervisor \
+          --kernel "/etc/bootitems/kernel/bzImage" \
+          --cmdline "console=ttyS0" \
+          --initramfs "/etc/bootitems/initrd/initrd" \
+          --serial "tty" \
+          --console "off" \
+          --memory size=1G'
+      '';
     });
   };
 


### PR DESCRIPTION
# Steps to Undraft
- [ ] make initrd boot again
  - the problem is that busybox, initrd, aren't copied into the nix store automatically anymore
  - not sure how to address this
- [ ] add test that boots initrd and minimal kernel