### PR TITLE
limine: unblock

### DIFF
--- a/common/nix/libutil/images/default.nix
+++ b/common/nix/libutil/images/default.nix
@@ -11,7 +11,15 @@
 }:
 
 let
-  limineX = limine.override ({ enableAll = true; });
+  # Limine with boot artifacts for x86 and x86_64.
+  limineX = limine.override ({
+    biosSupport = true;
+    buildCDs = true;
+    targets = [
+      "i686"
+      "x86_64"
+    ];
+  });
 
   scriptCheckIsMultiboot = writeShellScriptBin "check-is-multiboot" ''
     set -euo pipefail

--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755922037,
-        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
+        "lastModified": 1756217674,
+        "narHash": "sha256-TH1SfSP523QI7kcPiNtMAEuwZR3Jdz0MCDXPs7TS8uo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
+        "rev": "4e7667a90c167f7a81d906e5a75cba4ad8bee620",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Since `enableAll` is frequently broken (again, see https://github.com/NixOS/nixpkgs/issues/437787), I just drop it. I still think having `enableAll` working is a valid use-case in general, but I don't need it currently and in the near future.