### PR TITLE
common(nix,packages): fix bug in zsh-history-backup

### DIFF
--- a/common/nix/packages/zsh-history-backup/zsh-history-backup.sh
+++ b/common/nix/packages/zsh-history-backup/zsh-history-backup.sh
@@ -41,7 +41,6 @@ fn_restore_backup() {
 
 # Checks if we need to restore the backup.
 fn_need_restore() {
-  local WAS_TRUNCATED_THRESHOLD=100
   local RET_NEED_BACKUP_RESTORE=0
   local RET_NO_BACKUP_RESTORE=1
   local backup_size=0
@@ -65,7 +64,7 @@ fn_need_restore() {
   # We only need to restore the file when the file was truncated.
   echo "current history size=$current_size"
   echo "backup history size =$backup_size"
-  if [ "$current_size" -lt "$WAS_TRUNCATED_THRESHOLD" ] && [ "$current_size" -lt "$backup_size" ]; then
+  if [ "$current_size" -lt "$backup_size" ]; then
       return "$RET_NEED_BACKUP_RESTORE"
   else
       return "$RET_NO_BACKUP_RESTORE"


### PR DESCRIPTION
This better models the common failure scenario I have. For example, from my zsh backup history log:

ug 22 11:32:54 phips-framework13 zsh-history-backup[553637]: ✅ Backing up history file '/home/pschuster/.zsh_history' to '/home/pschus>
Aug 22 11:32:55 phips-framework13 systemd[2901]: Finished zsh-history-backup (per-user) service.
Aug 22 12:33:50 phips-framework13 systemd[2901]: Starting zsh-history-backup (per-user) service...
Aug 22 12:33:50 phips-framework13 zsh-history-backup[589457]: current history size=2143
Aug 22 12:33:50 phips-framework13 zsh-history-backup[589457]: backup history size =4158
Aug 22 12:33:50 phips-framework13 zsh-history-backup[589457]: ✅ Backing up history file '/home/pschuster/.zsh_history' to '/home/pschus>
Aug 22 12:33:50 phips-framework13 systemd[2901]: Finished zsh-history-backup (per-user) service.
Aug 22 13:34:50 phips-framework13 systemd[2901]: Starting zsh-history-backup (per-user) service...
Aug 22 13:34:50 phips-framework13 zsh-history-backup[598407]: current history size=2150
Aug 22 13:34:50 phips-framework13 zsh-history-backup[598407]: backup history size =2143