### PR TITLE
Reapply "common(modules,system): automatically clear /nix/var/nix/gcroots"

### DIFF
--- a/common/modules/system/nix-cfg.nix
+++ b/common/modules/system/nix-cfg.nix
@@ -18,6 +18,8 @@ let
         key = "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=";
       })
   ];
+
+  garbageCollectionPeriod = "30d";
 in
 {
   config = lib.mkIf cfg.enable {
@@ -75,7 +77,7 @@ in
         dates = "weekly";
         # Runs normal garbage-collection plus removes all NixOS generations
         # that are older than the specified amount.
-        options = "--delete-older-than 30d";
+        options = "--delete-older-than ${garbageCollectionPeriod}";
       };
 
       # Scheduled systemd service that optimizes all paths in the nix store
@@ -84,5 +86,16 @@ in
         automatic = true;
       };
     };
+
+    # Auto Nix GC Root Retention (angrr): Delete old result links, .direnv
+    # entries, and profiles from `/nix/var/nix/gcroots/` so that the next Nix
+    # garbage collection also deletes these files.
+    services.angrr = {
+      enable = true;
+      # Run this always before the service from `nix.gc.automatic
+      enableNixGcIntegration = true;
+      period = garbageCollectionPeriod;
+    };
+
   };
 }

--- a/common/modules/system/nix-cfg.nix
+++ b/common/modules/system/nix-cfg.nix
@@ -70,5 +70,38 @@ in
         automatic = true;
       };
     };
+
+    # Auto Nix GC Root Retention (angrr): Delete old result links, .direnv
+    # entries, and profiles from `/nix/var/nix/gcroots/` so that the next Nix
+    # garbage collection also deletes these files.
+    services.angrr = {
+      enable = true;
+      # Run this always before the service from `nix.gc.automatic
+      enableNixGcIntegration = true;
+      settings = {
+        profile-policies = {
+          # Delete old system profiles
+          system = {
+            keep-booted-system = true;
+            keep-current-system = true;
+            keep-latest-n = 4;
+            keep-since = "14d";
+            profile-paths = [
+              "/nix/var/nix/profiles/system"
+            ];
+          };
+        };
+        temporary-root-policies = {
+          direnv = {
+            path-regex = "/\\.direnv/";
+            period = "14d";
+          };
+          result = {
+            path-regex = "/result[^/]*$";
+            period = "14d";
+          };
+        };
+      };
+    };
   };
 }


### PR DESCRIPTION
This looks very cool but seems to be not that maturei n NixOS 25.11 and changes also seem to not be backported. Let's wait for NixOS 26.05.

